### PR TITLE
Add dynamic class support and ID validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The package will be automatically discovered by Laravel.
     font-size="2rem"
     color="#3490dc"
     cursor="_"
+    class="text-center my-4"
 />
 ```
 
@@ -106,6 +107,7 @@ The package will be automatically discovered by Laravel.
 | `cursor` | string | `\|` | Custom cursor character |
 | `font-size` | string | `1rem` | CSS font-size value |
 | `color` | string | `inherit` | CSS color value |
+| `class` | string | `null` | CSS class names for the container div |
 
 ## Publishing Views
 

--- a/resources/views/components/snl-type.blade.php
+++ b/resources/views/components/snl-type.blade.php
@@ -28,7 +28,7 @@
     $finalStrings = $useSlot ? [] : $strings;
 @endphp
 
-<div style="{{ $fontSize ? "font-size: {$fontSize}; " : '' }}{{ $color ? "color: {$color}; " : '' }}width: 100%;">
+<div {{ $class ? "class='{$class}'" : '' }} style="{{ $fontSize ? "font-size: {$fontSize}; " : '' }}{{ $color ? "color: {$color}; " : '' }}">
     <span id="{{ $id }}"></span>
 </div>
 @if($useSlot)

--- a/src/View/Components/SnlType.php
+++ b/src/View/Components/SnlType.php
@@ -5,6 +5,7 @@ namespace SticknoLogic\SnlType\View\Components;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 use Illuminate\Contracts\View\View;
+use InvalidArgumentException;
 
 /**
  * SnlType Blade Component
@@ -26,6 +27,7 @@ class SnlType extends Component
     public ?string $fontSize;
     public ?string $color;
     public ?string $cursor;
+    public ?string $class;
     public bool $hasSlotContent = false;
 
     /**
@@ -44,6 +46,7 @@ class SnlType extends Component
      * @param string|null $fontSize Font size CSS value
      * @param string|null $color Text color CSS value
      * @param string|null $cursor Custom cursor character
+     * @param string|null $class CSS class names for the container div
      */
     public function __construct(
         ?string $id = null,
@@ -58,9 +61,17 @@ class SnlType extends Component
         ?int $backDelay = null,
         ?string $fontSize = null,
         ?string $color = null,
-        ?string $cursor = null
+        ?string $cursor = null,
+        ?string $class = null
     ) {
-        $this->id = $id ?? Str::random(4);
+        // Validate custom ID starts with a letter
+        if ($id !== null && !preg_match('/^[a-zA-Z]/', $id)) {
+            throw new InvalidArgumentException(
+                "The 'id' attribute must start with an alphabetic character. Received: '{$id}'"
+            );
+        }
+        
+        $this->id = $id ?? 'z' . Str::random(3);
         $this->strings = is_string($strings) ? [$strings] : ($strings ?? []);
         $this->smartBackspace = $smartBackspace ?? true;
         $this->shuffle = $shuffle ?? false;
@@ -73,6 +84,7 @@ class SnlType extends Component
         $this->fontSize = $fontSize;
         $this->color = $color;
         $this->cursor = $cursor;
+        $this->class = $class;
     }
 
     /**


### PR DESCRIPTION
- Add 'class' attribute to dynamically apply CSS classes to container div
- Add validation to ensure custom IDs start with alphabetic character
- Auto-generated IDs now start with 'z' prefix (e.g., z1a2)
- Update README with class attribute documentation and examples
- Throws InvalidArgumentException for invalid ID format

closes #1 and closes #2