### PR TITLE
Fix class attribute rendering in snl-type component

### DIFF
--- a/resources/views/components/snl-type.blade.php
+++ b/resources/views/components/snl-type.blade.php
@@ -28,7 +28,7 @@
     $finalStrings = $useSlot ? [] : $strings;
 @endphp
 
-<div {{ $class ? "class='{$class}'" : '' }} style="{{ $fontSize ? "font-size: {$fontSize}; " : '' }}{{ $color ? "color: {$color}; " : '' }}">
+<div @if($class) class="{{ $class }}" @endif style="{{ $fontSize ? "font-size: {$fontSize}; " : '' }}{{ $color ? "color: {$color}; " : '' }}">
     <span id="{{ $id }}"></span>
 </div>
 @if($useSlot)


### PR DESCRIPTION
Updated the Blade template to use proper attribute binding for the class attribute, ensuring correct HTML output when a class is provided.